### PR TITLE
Start to returns the spinner to compress new & start & defer stop in one line…

### DIFF
--- a/spin.go
+++ b/spin.go
@@ -55,9 +55,9 @@ func (s *Spinner) Set(frames string) {
 }
 
 // Start shows the spinner.
-func (s *Spinner) Start() {
+func (s *Spinner) Start() *Spinner {
 	if atomic.LoadUint64(&s.active) > 0 {
-		return
+		return s
 	}
 	atomic.StoreUint64(&s.active, 1)
 	go func() {
@@ -66,6 +66,7 @@ func (s *Spinner) Start() {
 			time.Sleep(100 * time.Millisecond)
 		}
 	}()
+	return s
 }
 
 // Stop hides the spinner.


### PR DESCRIPTION
This permits compressing the initialization, start and stop of the spinner in one line like this

`defer spin.New("%s cloning...").Start().Stop()`